### PR TITLE
Remove CPUTemplate to test non-intel instance

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/firecracker-microvm/firecracker-containerd/internal"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,14 +32,16 @@ func TestLoadConfigDefaults(t *testing.T) {
 	assert.Equal(t, defaultKernelArgs, cfg.KernelArgs, "expected default kernel args")
 	assert.Equal(t, defaultKernelPath, cfg.KernelImagePath, "expected default kernel path")
 	assert.Equal(t, defaultRootfsPath, cfg.RootDrive, "expected default rootfs path")
-	assert.Equal(t, string(defaultCPUTemplate), cfg.CPUTemplate, "expected default CPU template")
 }
 
 func TestLoadConfigOverrides(t *testing.T) {
 	overrideKernelArgs := "OVERRIDE KERNEL ARGS"
 	overrideKernelPath := "OVERRIDE KERNEL PATH"
 	overrideRootfsPath := "OVERRIDE ROOTFS PATH"
-	overrideCPUTemplate := "OVERRIDE CPU TEMPLATE"
+	overrideCPUTemplate := ""
+	if cpuTemp, err := internal.SupportCPUTemplate(); cpuTemp && err == nil {
+		overrideCPUTemplate = "OVERRIDE CPU TEMPLATE"
+	}
 	configContent := fmt.Sprintf(
 		`{
 			"kernel_args":"%s",

--- a/runtime/service_test.go
+++ b/runtime/service_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/firecracker-microvm/firecracker-containerd/config"
+	"github.com/firecracker-microvm/firecracker-containerd/internal"
 	"github.com/firecracker-microvm/firecracker-containerd/internal/debug"
 	"github.com/firecracker-microvm/firecracker-containerd/internal/vm"
 	"github.com/firecracker-microvm/firecracker-containerd/proto"
@@ -225,6 +226,9 @@ func TestBuildVMConfiguration(t *testing.T) {
 	}
 
 	for _, tc := range testcases {
+		if cpuTemp, err := internal.SupportCPUTemplate(); !cpuTemp && err == nil {
+			tc.expectedCfg.MachineCfg.CPUTemplate = ""
+		}
 		tc := tc // see https://github.com/kyoh86/scopelint/issues/4
 		t.Run(tc.name, func(t *testing.T) {
 			svc := &service{


### PR DESCRIPTION
Signed-off-by: Vaishnavi Vejella <vvejella@amazon.com>

*Issue:* When testing an AMD instance against Firecracker-containerd, the BuildKite pipeline tests fail due to CPUTemplate, which is not supported by non-intel instance.
*Description of changes:* By assigning an empty string to the CPUTemplate field we are conducting tests against the instance to check, if this field is supported by` internal.SupportCPUTemplate(). `


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
